### PR TITLE
test: use correct absolute `last_line` when encoding mock semantic tokens

### DIFF
--- a/lua/tests/lsp_server.lua
+++ b/lua/tests/lsp_server.lua
@@ -7,9 +7,10 @@ local M = {}
 ---@return table<integer> data
 local function encode_token_positions(positions)
   local data = {}
+  local last_line = 0
   for _, pos in ipairs(positions) do
-    local last_line = data[#data - 4] or 0
     local relative_line = pos.line - last_line
+    last_line = pos.line
     local last_col = data[#data - 3] or 0
     local relative_col = relative_line == 0 and pos.col - last_col or pos.col
     vim.list_extend(data, {
@@ -51,6 +52,8 @@ function M.mock_server(var_sem_tokens)
         callback(nil, nil)
       elseif method == 'textDocument/semanticTokens/full' then
         callback(nil, { data = encode_token_positions(var_sem_tokens) })
+      else
+        print('mock_server: unhandled method ' .. method, vim.inspect(params))
       end
       return true, 1
     end

--- a/lua/tests/sample_spec.lua
+++ b/lua/tests/sample_spec.lua
@@ -159,6 +159,9 @@ local function setup_tests(lang)
           }
         end
         assert.are.same(expected_globals, highlighted)
+
+        -- stop lsp client
+        vim.lsp.stop_client(client_id)
       end)
     end
   end)


### PR DESCRIPTION
and some minor test tweaks